### PR TITLE
chore: bump `autotools` to `0.2.5`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "autotools"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec8e3c65baca58d892ae26d20bbe34713d20d0b02fd0ced4254f256aebbbb80"
+checksum = "c8138adefca3e5d2e73bfba83bd6eeaf904b26a7ac1b4a19892cfe16cc7e1701"
 dependencies = [
  "cc",
 ]

--- a/protobuf-src/Cargo.toml
+++ b/protobuf-src/Cargo.toml
@@ -30,4 +30,4 @@ edition = "2021"
 links = "protobuf-src"
 
 [build-dependencies]
-autotools = "0.2.4"
+autotools = "0.2.5"


### PR DESCRIPTION
Seems to be blocking minversions check in https://github.com/tokio-rs/prost/pull/657

cc @benesch 