### PR TITLE
Add missing DeleteCodedOutputStream function, protobuf-native: release 0.2.2+3.19.1

### DIFF
--- a/protobuf-native/CHANGELOG.md
+++ b/protobuf-native/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
+* Fix linking by adding the `DeleteCodedOutputStream` function
+
 ## [0.2.1+3.19.1] - 2022-01-18
 
 * Fix the file descriptor traversal in

--- a/protobuf-native/src/io.cc
+++ b/protobuf-native/src/io.cc
@@ -108,5 +108,7 @@ CodedInputStream* NewCodedInputStream(ZeroCopyInputStream* input) {
 
 void DeleteCodedInputStream(CodedInputStream* stream) { delete stream; }
 
+void DeleteCodedOutputStream(CodedOutputStream* stream) { delete stream; }
+
 }  // namespace io
 }  // namespace protobuf_native


### PR DESCRIPTION
As noticed in https://github.com/MaterializeInc/materialize/pull/25177

Also noticed elsewhere: https://github.com/rust-lang/rustc_codegen_cranelift/issues/1411