### PR TITLE
build: Allow specifying RUST_PROTOBUF_SRC_PROTOC env variable

### DIFF
--- a/protobuf-src/build.rs
+++ b/protobuf-src/build.rs
@@ -19,6 +19,12 @@ use std::fs;
 use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn Error>> {
+    // Note: Keep this environment variable in sync with the library.
+    if let Some(path) = option_env!("RUST_PROTOBUF_SRC_PROTOC") {
+        eprintln!("Skipping build of protoc, override path provided: '{path}'");
+        return Ok(());
+    }
+
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
     let install_dir = out_dir.join("install");
     fs::create_dir_all(&install_dir)?;

--- a/protobuf-src/src/lib.rs
+++ b/protobuf-src/src/lib.rs
@@ -51,14 +51,20 @@
 
 use std::path::PathBuf;
 
+// Note: Keep this environment variable in sync with the build script.
+static OVERRIDE_PATH: Option<&'static str> = option_env!("RUST_PROTOBUF_SRC_PROTOC");
+static INSTALL_DIR: Option<&'static str> = option_env!("INSTALL_DIR");
+
 /// Returns the path to the vendored protoc binary.
 pub fn protoc() -> PathBuf {
-    PathBuf::from(env!("INSTALL_DIR"))
-        .join("bin")
-        .join("protoc")
+    match (OVERRIDE_PATH, INSTALL_DIR) {
+        (Some(override_path), _) => PathBuf::from(override_path),
+        (_, Some(install_dir)) => PathBuf::from(install_dir).join("bin").join("protoc"),
+        (None, None) => panic!("An override path was not specified, nor was the build script run!"),
+    }
 }
 
 /// Returns the path to the vendored include directory.
-pub fn include() -> PathBuf {
-    PathBuf::from(env!("INSTALL_DIR")).join("include")
+pub fn include() -> Option<PathBuf> {
+    INSTALL_DIR.map(|path| PathBuf::from(path).join("include"))
 }


### PR DESCRIPTION
This PR allows users to specify a path to an existing instance of `protoc`, which will skip building the vendored version. This is useful for build processes where we don't want to use the build script (e.g. Bazel) or for processes that want to provide their own version of `protoc`.