### PR TITLE
protobuf-src: don't let CMake install to lib64

### DIFF
--- a/protobuf-native/src/compiler.rs
+++ b/protobuf-native/src/compiler.rs
@@ -115,7 +115,11 @@ pub(crate) mod ffi {
         type DiskSourceTree;
         fn NewDiskSourceTree() -> *mut DiskSourceTree;
         unsafe fn DeleteDiskSourceTree(tree: *mut DiskSourceTree);
-        fn MapPath(self: Pin<&mut DiskSourceTree>, virtual_path: string_view, disk_path: string_view);
+        fn MapPath(
+            self: Pin<&mut DiskSourceTree>,
+            virtual_path: string_view,
+            disk_path: string_view,
+        );
     }
 }
 
@@ -444,7 +448,8 @@ impl DiskSourceTree {
     pub fn map_path(self: Pin<&mut Self>, virtual_path: &Path, disk_path: &Path) {
         let virtual_path = ProtobufPath::from(virtual_path);
         let disk_path = ProtobufPath::from(disk_path);
-        self.as_ffi_mut().MapPath(virtual_path.into(), disk_path.into())
+        self.as_ffi_mut()
+            .MapPath(virtual_path.into(), disk_path.into())
     }
 
     unsafe_ffi_conversions!(ffi::DiskSourceTree);

--- a/protobuf-native/src/internal.rs
+++ b/protobuf-native/src/internal.rs
@@ -53,7 +53,7 @@ pub struct StringView {
 
 impl<S> From<S> for StringView
 where
-    S: AsRef<[u8]>
+    S: AsRef<[u8]>,
 {
     fn from(s: S) -> StringView {
         StringView {

--- a/protobuf-src/build.rs
+++ b/protobuf-src/build.rs
@@ -21,6 +21,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         .define("protobuf_BUILD_TESTS", "OFF")
         .define("protobuf_DEBUG_POSTFIX", "")
         .define("CMAKE_CXX_STANDARD", "14")
+        // CMAKE_INSTALL_LIBDIR is inferred as "lib64" on some platforms, but we
+        // want a stable location that we can add to the linker search path.
+        // Since we're not actually installing to /usr or /usr/local, there's no
+        // harm to always using "lib" here.
+        .define("CMAKE_INSTALL_LIBDIR", "lib")
         .build();
 
     println!("cargo:rustc-env=INSTALL_DIR={}", install_dir.display());


### PR DESCRIPTION
`CMAKE_INSTALL_LIBDIR` is inferred as "lib64" on some platforms, but we want a stable location that we can add to the linker search path. Since we're not actually installing to /usr or /usr/local, there's no harm to always using "lib" here.