### PR TITLE
Change C `include` statements to use `"` instead of `<`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
             os: ubuntu-latest
             rust: stable
           - build: ubuntu-old
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             rust: stable
           - build: macos
             os: macos-latest
@@ -29,6 +29,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install Rust (rustup)
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
+    - run: clang --version
     - run: cargo test
 
   lint:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         - macos
         include:
           - build: ubuntu
-            os: ubuntu-latest
+            os: ubuntu-24.04
             rust: stable
           - build: ubuntu-old
             os: ubuntu-20.04
@@ -29,7 +29,6 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install Rust (rustup)
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
-    - run: clang --version
     - run: cargo test
 
   lint:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,9 @@ jobs:
       matrix:
         build:
         - ubuntu
-        - ubuntu-old
         - macos
         include:
           - build: ubuntu
-            os: ubuntu-24.04
-            rust: stable
-          - build: ubuntu-old
             os: ubuntu-20.04
             rust: stable
           - build: macos

--- a/protobuf-native/src/compiler.h
+++ b/protobuf-native/src/compiler.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <google/protobuf/compiler/importer.h>
+#include "google/protobuf/compiler/importer.h"
 
 #include "rust/cxx.h"
 

--- a/protobuf-native/src/compiler.h
+++ b/protobuf-native/src/compiler.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include "google/protobuf/compiler/importer.h"
-
 #include "rust/cxx.h"
 
 namespace protobuf_native {

--- a/protobuf-native/src/internal.h
+++ b/protobuf-native/src/internal.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <absl/strings/string_view.h>
+#include "absl/strings/string_view.h"
 
 namespace protobuf_native {
 namespace internal {

--- a/protobuf-native/src/io.h
+++ b/protobuf-native/src/io.h
@@ -15,13 +15,12 @@
 
 #pragma once
 
+#include <memory>
+
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/io/zero_copy_stream.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "google/protobuf/io/zero_copy_stream_impl_lite.h"
-
-#include <memory>
-
 #include "rust/cxx.h"
 
 namespace protobuf_native {

--- a/protobuf-native/src/io.h
+++ b/protobuf-native/src/io.h
@@ -15,10 +15,10 @@
 
 #pragma once
 
-#include <google/protobuf/io/coded_stream.h>
-#include <google/protobuf/io/zero_copy_stream.h>
-#include <google/protobuf/io/zero_copy_stream_impl.h>
-#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+#include "google/protobuf/io/coded_stream.h"
+#include "google/protobuf/io/zero_copy_stream.h"
+#include "google/protobuf/io/zero_copy_stream_impl.h"
+#include "google/protobuf/io/zero_copy_stream_impl_lite.h"
 
 #include <memory>
 

--- a/protobuf-native/src/lib.h
+++ b/protobuf-native/src/lib.h
@@ -15,8 +15,8 @@
 
 #pragma once
 
-#include <google/protobuf/descriptor.h>
-#include <google/protobuf/descriptor.pb.h>
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/descriptor.pb.h"
 
 #include <memory>
 

--- a/protobuf-native/src/lib.h
+++ b/protobuf-native/src/lib.h
@@ -15,10 +15,10 @@
 
 #pragma once
 
+#include <memory>
+
 #include "google/protobuf/descriptor.h"
 #include "google/protobuf/descriptor.pb.h"
-
-#include <memory>
 
 using namespace google::protobuf;
 


### PR DESCRIPTION
AFAIU using angle brackets for `#include` statements is generally used for system headers while double-quotes prioritizes headers in the current working directory ([stackoverflow](https://stackoverflow.com/questions/3162030/difference-between-angle-bracket-and-double-quotes-while-including-heade)). It's compiler dependent, but using double-quotes fixes some issues I ran into while building with clang via Bazel