### PR TITLE
protobuf-native: Bump version to `v0.3.1`

### DIFF
--- a/protobuf-native/CHANGELOG.md
+++ b/protobuf-native/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
+## [0.3.1] - 2024-06-10
+
+* Use double-quotes for `#include` statements in C headers for non-system files.
+
 ## [0.3.0] - 2024-05-13
 
 * Upgrade to protobuf-src v2.0.0+26.1.


### PR DESCRIPTION
Bump the version number of `protobuf-native` so we can release https://github.com/MaterializeInc/rust-protobuf-native/pull/16