### PR TITLE
protobuf-native: fix memory safety issue with absl::string_view

### DIFF
--- a/protobuf-native/CHANGELOG.md
+++ b/protobuf-native/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
+* Fix memory safety issue with `absl::string_view` that presented when linking
+  with libstdc++.
+
 ## [0.3.1] - 2024-06-11
 
 * Use double-quotes for `#include` statements in C headers for non-system files.

--- a/protobuf-native/src/internal.h
+++ b/protobuf-native/src/internal.h
@@ -16,12 +16,21 @@
 #pragma once
 
 #include "absl/strings/string_view.h"
+#include "rust/cxx.h"
 
 namespace protobuf_native {
 namespace internal {
 
 typedef int CInt;
 typedef void CVoid;
+
+static_assert(sizeof(absl::string_view) == 2 * sizeof(void *), "");
+static_assert(alignof(absl::string_view) == alignof(void *), "");
+
+inline absl::string_view string_view_from_bytes(rust::Slice<const uint8_t> s) {
+    const char *data = reinterpret_cast<const char *>(s.data());
+    return {data, s.size()};
+}
 
 }  // namespace internal
 }  // namespace protobuf_native


### PR DESCRIPTION
Assuming the order of members in this class is not safe, as it varies between toolchains. Adjust so that we always construct the struct in Rust via a C++ function.