### PR TITLE
build: Add the `parallel` feature, set `-j` arg based on `NUM_JOBS`

### DIFF
--- a/protobuf-src/Cargo.toml
+++ b/protobuf-src/Cargo.toml
@@ -31,3 +31,7 @@ links = "protobuf-src"
 
 [build-dependencies]
 cmake = "0.1.50"
+
+[features]
+default = ["parallel"]
+parallel = []


### PR DESCRIPTION
This PR speeds up builds of `protobuf-src` for me from ~5 minutes to ~1 minute.

There's probably a higher level issue that I haven't dug into here yet, the actually `cmake` command that gets run, _without this PR_, is:

```
MAKEFLAGS="-j --jobserver-fds=8,9 --jobserver-auth=8,9" cmake --build . --target install --config Debug
```

This should parallelize the build with Cargo's jobserver (I think?), but something seems to go wrong and at least locally, after ~30 seconds I only see one instance of `clang` running.

With this PR the `cmake` command is updated to:

```
MAKEFLAGS="-j --jobserver-fds=8,9 --jobserver-auth=8,9" cmake --build . --target install --config Debug -- -j12
```

Further, looking at the logs from `cmake` this seems to disable jobserver mode:
```
[protobuf-src 2.1.0+27.1] make: warning: -jN forced in submake: disabling jobserver mode.
```

This isn't ideal, but something seems to be going wrong with Cargo's job server which is seriously slowing down builds.