### PR TITLE
Add aarch64 test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,14 @@ jobs:
       matrix:
         build:
         - ubuntu
+        - ubuntu-arm
         - macos
         include:
           - build: ubuntu
             os: ubuntu-20.04
+            rust: stable
+          - build: ubuntu-arm
+            os: ubuntu-20.04-arm
             rust: stable
           - build: macos
             os: macos-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
             os: ubuntu-20.04
             rust: stable
           - build: ubuntu-arm
-            os: ubuntu-20.04-arm
+            os: ubuntu-22.04-arm
             rust: stable
           - build: macos
             os: macos-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         - macos
         include:
           - build: ubuntu
-            os: ubuntu-22.04
+            os: ubuntu-20.04
             rust: stable
           - build: ubuntu-arm
             os: ubuntu-22.04-arm

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,10 @@ jobs:
         - macos
         include:
           - build: ubuntu
-            os: ubuntu-20.04
+            os: ubuntu-24.04
             rust: stable
           - build: ubuntu-arm
-            os: ubuntu-22.04-arm
+            os: ubuntu-24.04-arm
             rust: stable
           - build: macos
             os: macos-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,10 @@ jobs:
         - macos
         include:
           - build: ubuntu
-            os: ubuntu-24.04
+            os: ubuntu-22.04
             rust: stable
           - build: ubuntu-arm
-            os: ubuntu-24.04-arm
+            os: ubuntu-22.04-arm
             rust: stable
           - build: macos
             os: macos-latest


### PR DESCRIPTION
For context, I'm having issue building a library that relies on protobuf-src, on linux aarch64 / ubuntu-amd.

It seems to work fine here, so the issue must be on my side.

BTW, I've noticed some issues:
- when building on ubuntu-24-04 (something to do with `timex::timeval`): https://github.com/0x26res/rust-protobuf-native/actions/runs/15064727308/job/42346913038
- when building on ubuntu-24-04-arm (same issue): https://github.com/0x26res/rust-protobuf-native/actions/runs/15064727308/job/42346913026
- when building on ubuntu-22-04 (`use of undeclared identifier '__builtin_ia32_paddsb128'`): https://github.com/0x26res/rust-protobuf-native/actions/runs/15064929893/job/42347545362

