### PR TITLE
feat: windows support

### DIFF
--- a/protobuf-native/build.rs
+++ b/protobuf-native/build.rs
@@ -26,7 +26,7 @@ fn main() {
         "src/io.rs",
         "src/lib.rs",
     ])
-    .flag("-std=c++14")
+    .std("c++14")
     .files(["src/compiler.cc", "src/io.cc", "src/lib.cc"])
     .warnings_into_errors(cfg!(deny_warnings))
     .compile("protobuf_native");
@@ -129,6 +129,9 @@ fn main() {
         "absl_time_zone",
         "absl_utf8_for_code_point",
         "absl_vlog_config_internal",
+        #[cfg(windows)]
+        "libprotobuf",
+        #[cfg(not(windows))]
         "protobuf",
         "utf8_validity",
     ] {
@@ -180,7 +183,7 @@ fn collect_proto_files(base_dir: &Path, current_dir: &Path, files: &mut Vec<(Str
         let path = entry.path();
         if path.is_dir() {
             collect_proto_files(base_dir, &path, files);
-        } else if path.extension().map_or(false, |ext| ext == "proto") {
+        } else if path.extension().is_some_and(|ext| ext == "proto") {
             if let Ok(relative) = path.strip_prefix(base_dir) {
                 files.push((
                     relative.to_string_lossy().into_owned(),

--- a/protobuf-native/src/compiler.cc
+++ b/protobuf-native/src/compiler.cc
@@ -35,11 +35,9 @@ void SimpleErrorCollector::RecordWarning(absl::string_view filename, int line, i
 
 void SimpleErrorCollector::RecordErrorOrWarning(absl::string_view filename, int line, int column,
                                                 absl::string_view message, bool warning) {
-    errors_.push_back(FileLoadError{.filename = rust::String(filename.data(), filename.size()),
-                                    .line = line,
-                                    .column = column,
-                                    .message = rust::String(message.data(), message.size()),
-                                    .warning = warning});
+    // TODO: use designated initializers when std("c++20") is enabled in build.rs
+    errors_.push_back(FileLoadError{rust::String(filename.data(), filename.size()), line, column,
+                                    rust::String(message.data(), message.size()), warning});
 }
 
 std::vector<FileLoadError>& SimpleErrorCollector::Errors() { return errors_; }

--- a/protobuf-native/src/compiler.rs
+++ b/protobuf-native/src/compiler.rs
@@ -223,7 +223,7 @@ impl SimpleErrorCollector {
     unsafe_ffi_conversions!(ffi::SimpleErrorCollector);
 }
 
-impl<'a> Iterator for Pin<&'a mut SimpleErrorCollector> {
+impl Iterator for Pin<&mut SimpleErrorCollector> {
     type Item = FileLoadError;
 
     fn next(&mut self) -> Option<FileLoadError> {
@@ -355,7 +355,7 @@ pub trait SourceTree: source_tree::Sealed {
     ) -> Result<Pin<Box<DynZeroCopyInputStream<'a>>>, FileOpenError> {
         let filename = ProtobufPath::from(filename);
         let mut source_tree = self.upcast_mut();
-        let stream = source_tree.as_mut().Open(filename.into());
+        let stream = source_tree.as_mut().Open(filename.as_string_view());
         if stream.is_null() {
             Err(FileOpenError(ffi::SourceTreeGetLastErrorMessage(
                 source_tree,
@@ -401,7 +401,8 @@ impl VirtualSourceTree {
     /// Adds a file to the source tree with the specified name and contents.
     pub fn add_file(self: Pin<&mut Self>, filename: &Path, contents: Vec<u8>) {
         let filename = ProtobufPath::from(filename);
-        self.as_ffi_mut().AddFile(filename.into(), contents)
+        self.as_ffi_mut()
+            .AddFile(filename.as_string_view(), contents)
     }
 
     /// Maps the well-known protobuf types to the source tree.
@@ -510,7 +511,7 @@ impl DiskSourceTree {
         let virtual_path = ProtobufPath::from(virtual_path);
         let disk_path = ProtobufPath::from(disk_path);
         self.as_ffi_mut()
-            .MapPath(virtual_path.into(), disk_path.into())
+            .MapPath(virtual_path.as_string_view(), disk_path.as_string_view())
     }
 
     /// Maps the well-known protobuf types to the source tree.

--- a/protobuf-native/src/internal.h
+++ b/protobuf-native/src/internal.h
@@ -24,11 +24,11 @@ namespace internal {
 typedef int CInt;
 typedef void CVoid;
 
-static_assert(sizeof(absl::string_view) == 2 * sizeof(void *), "");
-static_assert(alignof(absl::string_view) == alignof(void *), "");
+static_assert(sizeof(absl::string_view) == 2 * sizeof(void*), "");
+static_assert(alignof(absl::string_view) == alignof(void*), "");
 
 inline absl::string_view string_view_from_bytes(rust::Slice<const uint8_t> s) {
-    const char *data = reinterpret_cast<const char *>(s.data());
+    const char* data = reinterpret_cast<const char*>(s.data());
     return {data, s.size()};
 }
 

--- a/protobuf-native/src/internal.rs
+++ b/protobuf-native/src/internal.rs
@@ -13,21 +13,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(unix)]
-use std::ffi::OsStr;
 use std::fmt;
 use std::io::{Read, Write};
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::os::raw::{c_char, c_int, c_void};
-#[cfg(unix)]
-use std::os::unix::prelude::OsStrExt;
-use std::path::Path;
 
 use cxx::kind::Trivial;
 use cxx::{type_id, ExternType};
 
 use crate::OperationFailedError;
+
+#[cfg(unix)]
+pub use self::unix::ProtobufPath;
+#[cfg(windows)]
+pub use self::windows::ProtobufPath;
 
 // Pollyfill C++ APIs that aren't yet in cxx.
 // See: https://github.com/dtolnay/cxx/pull/984
@@ -47,7 +47,7 @@ mod ffi {
         type StringView<'a> = crate::internal::StringView<'a>;
 
         #[namespace = "protobuf_native::internal"]
-        fn string_view_from_bytes(bytes: &[u8]) -> StringView;
+        fn string_view_from_bytes<'a>(bytes: &'a [u8]) -> StringView<'a>;
     }
 }
 
@@ -65,12 +65,6 @@ pub struct StringView<'a> {
 impl<'a> From<&'a str> for StringView<'a> {
     fn from(s: &'a str) -> StringView<'a> {
         ffi::string_view_from_bytes(s.as_bytes())
-    }
-}
-
-impl<'a> From<ProtobufPath<'a>> for StringView<'a> {
-    fn from(path: ProtobufPath<'a>) -> StringView<'a> {
-        ffi::string_view_from_bytes(path.as_bytes())
     }
 }
 
@@ -160,10 +154,7 @@ pub trait ResultExt {
 
 impl<T, E> ResultExt for Result<T, E> {
     fn as_status(&self) -> bool {
-        match self {
-            Ok(_) => true,
-            Err(_) => false,
-        }
+        self.is_ok()
     }
 }
 
@@ -173,11 +164,11 @@ pub trait BoolExt {
     ///
     /// If the status boolean is true, returns `Ok`. If the status boolean is
     /// false, returns `Err`.
-    fn as_result(self) -> Result<(), OperationFailedError>;
+    fn to_result(self) -> Result<(), OperationFailedError>;
 }
 
 impl BoolExt for bool {
-    fn as_result(self) -> Result<(), OperationFailedError> {
+    fn to_result(self) -> Result<(), OperationFailedError> {
         match self {
             true => Ok(()),
             false => Err(OperationFailedError),
@@ -185,88 +176,102 @@ impl BoolExt for bool {
     }
 }
 
-/// An adapter for passing paths to `libprotobuf`.
-///
-/// On Unix, the bytes in a path can be passed directly.
-///
-/// On Windows, the situation is complicated. Protobuf assumes paths are UTF-8
-/// and converts them to wide-character strings before passing them to the
-/// underlying Windows wide-char APIs. But paths in Rust might not valid UTF-8.
-/// There's not much we can do to handle invalid UTF-8 correctly; we just throw
-/// `to_string_lossy` at the problem and hope `libprotobuf` sorts it out.
-///
-/// The point is to make this correct and performant on Unix in all cases, and
-/// correct in Windows as long as the path is valid UTF-8.
 #[cfg(unix)]
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct ProtobufPath<'a>(&'a Path);
+mod unix {
+    use super::StringView;
+    use std::{ffi::OsStr, os::unix::prelude::OsStrExt, path::Path};
 
-#[cfg(windows)]
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct ProtobufPath<'a> {
-    inner: Vec<u8>,
-    _phantom: PhantomData<'a>,
-}
+    /// An adapter for passing paths to `libprotobuf`.
+    ///
+    /// On Unix, the bytes in a path can be passed directly.
+    ///
+    /// The point is to make this correct and performant on Unix in all cases, and
+    /// correct in Windows as long as the path is valid UTF-8.
+    #[derive(Debug, Clone, Eq, PartialEq, Hash)]
+    pub struct ProtobufPath<'a>(&'a Path);
 
-#[cfg(unix)]
-impl<'a> ProtobufPath<'a> {
-    pub fn as_path(&self) -> impl AsRef<Path> + 'a {
-        self.0
+    impl<'a> ProtobufPath<'a> {
+        pub fn as_path(&self) -> impl AsRef<Path> + 'a {
+            self.0
+        }
+
+        pub fn as_bytes(&self) -> &'a [u8] {
+            self.0.as_os_str().as_bytes()
+        }
+
+        pub fn as_string_view(&'a self) -> StringView<'a> {
+            super::ffi::string_view_from_bytes(self.as_bytes())
+        }
     }
-}
 
-#[cfg(unix)]
-impl<'a> From<&'a [u8]> for ProtobufPath<'a> {
-    fn from(p: &'a [u8]) -> ProtobufPath<'a> {
-        ProtobufPath(Path::new(OsStr::from_bytes(p)))
+    impl<'a> From<&'a [u8]> for ProtobufPath<'a> {
+        fn from(p: &'a [u8]) -> ProtobufPath<'a> {
+            ProtobufPath(Path::new(OsStr::from_bytes(p)))
+        }
     }
-}
 
-#[cfg(unix)]
-impl<'a> From<&'a Path> for ProtobufPath<'a> {
-    fn from(p: &'a Path) -> ProtobufPath<'a> {
-        ProtobufPath(p)
-    }
-}
-
-#[cfg(unix)]
-impl<'a> ProtobufPath<'a> {
-    pub fn as_bytes(&self) -> &'a [u8] {
-        self.0.as_os_str().as_bytes()
-    }
-}
-
-#[cfg(windows)]
-impl<'a> ProtobufPath<'a> {
-    pub fn as_path(&self) -> impl AsRef<Path> {
-        PathBuf::from(String::from_utf8_lossy(self.inner))
-    }
-}
-
-#[cfg(windows)]
-impl<'a> From<&'a [u8]> for ProtobufPath<'static> {
-    fn from(p: &'a [u8]) -> ProtobufPath<'static> {
-        ProtobufPath {
-            inner: p.to_vec(),
-            _phantom: PhantomData,
+    impl<'a> From<&'a Path> for ProtobufPath<'a> {
+        fn from(p: &'a Path) -> ProtobufPath<'a> {
+            ProtobufPath(p)
         }
     }
 }
 
 #[cfg(windows)]
-impl<'a> From<Path> for ProtobufPath<'a> {
-    fn from(p: Path) -> ProtobufPath<'a> {
-        ProtobufPath {
-            inner: p.to_string_lossy().into_owned().into_bytes(),
-            _phantom: PhantomData,
+mod windows {
+    use super::StringView;
+    use std::{
+        marker::PhantomData,
+        path::{Path, PathBuf},
+    };
+
+    /// An adapter for passing paths to `libprotobuf`.
+    ///
+    /// On Windows, the situation is complicated.
+    /// Protobuf assumes paths are UTF-8 and converts them to wide-character strings
+    /// before passing them to the underlying Windows wide-char APIs.
+    /// But paths in Rust might not valid UTF-8.
+    /// There's not much we can do to handle invalid UTF-8 correctly; we just throw
+    /// `to_string_lossy` at the problem and hope `libprotobuf` sorts it out.
+    ///
+    /// The point is to make this correct and performant on Unix in all cases, and
+    /// correct in Windows as long as the path is valid UTF-8.
+    #[derive(Debug, Clone, Eq, PartialEq, Hash)]
+    pub struct ProtobufPath<'a> {
+        inner: Vec<u8>,
+        _phantom: PhantomData<&'a Path>,
+    }
+
+    impl<'a> ProtobufPath<'a> {
+        pub fn as_path(&self) -> impl AsRef<Path> {
+            PathBuf::from(String::from_utf8_lossy(&self.inner).into_owned())
+        }
+
+        pub fn as_bytes(&'a self) -> &'a [u8] {
+            &self.inner
+        }
+
+        pub fn as_string_view(&'a self) -> StringView<'a> {
+            super::ffi::string_view_from_bytes(self.as_bytes())
         }
     }
-}
 
-#[cfg(windows)]
-impl<'a> ProtobufPath<'a> {
-    pub fn as_bytes(&self) -> &'a [u8] {
-        &self.inner
+    impl<'a> From<&'a [u8]> for ProtobufPath<'a> {
+        fn from(p: &'a [u8]) -> ProtobufPath<'a> {
+            ProtobufPath {
+                inner: p.to_vec(),
+                _phantom: PhantomData,
+            }
+        }
+    }
+
+    impl<'a> From<&'a Path> for ProtobufPath<'a> {
+        fn from(p: &'a Path) -> ProtobufPath<'a> {
+            ProtobufPath {
+                inner: p.to_string_lossy().into_owned().into_bytes(),
+                _phantom: PhantomData,
+            }
+        }
     }
 }
 
@@ -279,7 +284,7 @@ macro_rules! unsafe_ffi_conversions {
 
         #[allow(dead_code)]
         pub(crate) unsafe fn from_ffi_ptr<'_a>(from: *const $ty) -> &'_a Self {
-            std::mem::transmute(from)
+            &*(from as *const Self)
         }
 
         #[allow(dead_code)]
@@ -309,7 +314,7 @@ macro_rules! unsafe_ffi_conversions {
 
         #[allow(dead_code)]
         pub(crate) unsafe fn as_ffi_mut_ptr_unpinned(&mut self) -> *mut $ty {
-            std::mem::transmute(self)
+            self as *mut Self as *mut $ty
         }
     };
 }

--- a/protobuf-native/src/io.rs
+++ b/protobuf-native/src/io.rs
@@ -234,7 +234,7 @@ pub trait ZeroCopyInputStream: zero_copy_input_stream::Sealed {
             // SAFETY: `data` and `size` are non-null, as required.
             self.upcast_mut()
                 .Next(data.as_mut_ptr(), size.as_mut_ptr())
-                .as_result()?;
+                .to_result()?;
             // SAFETY: `Next` has succeeded and so has promised to provide us
             // with a valid buffer.
             let data = data.assume_init() as *const u8;
@@ -275,7 +275,7 @@ pub trait ZeroCopyInputStream: zero_copy_input_stream::Sealed {
     /// [`byte_count`]: ZeroCopyInputStream::byte_count
     fn skip(self: Pin<&mut Self>, count: usize) -> Result<(), OperationFailedError> {
         let count = CInt::try_from(count).map_err(|_| OperationFailedError)?;
-        self.upcast_mut().Skip(count).as_result()
+        self.upcast_mut().Skip(count).to_result()
     }
 
     /// Returns the total number of bytes read since this stream was created.
@@ -452,7 +452,7 @@ pub trait ZeroCopyOutputStream: zero_copy_output_stream::Sealed {
         let mut size = MaybeUninit::uninit();
         self.upcast_mut()
             .Next(data.as_mut_ptr(), size.as_mut_ptr())
-            .as_result()?;
+            .to_result()?;
         let data = data.assume_init() as *mut MaybeUninit<u8>;
         let size = size.assume_init().to_usize()?;
         Ok(slice::from_raw_parts_mut(data, size))

--- a/protobuf-native/src/lib.rs
+++ b/protobuf-native/src/lib.rs
@@ -327,7 +327,7 @@ pub trait MessageLite: private::MessageLite {
         unsafe {
             self.upcast_mut()
                 .MergeFromCodedStream(input.as_ffi_mut_ptr())
-                .as_result()
+                .to_result()
         }
     }
 
@@ -341,7 +341,7 @@ pub trait MessageLite: private::MessageLite {
         unsafe {
             self.upcast()
                 .SerializeToCodedStream(output.as_ffi_mut_ptr())
-                .as_result()
+                .to_result()
         }
     }
 
@@ -355,7 +355,7 @@ pub trait MessageLite: private::MessageLite {
         unsafe {
             self.upcast()
                 .SerializeToZeroCopyStream(output.upcast_mut_ptr())
-                .as_result()
+                .to_result()
         }
     }
 

--- a/protobuf-native/tests/protobuf-native/main.rs
+++ b/protobuf-native/tests/protobuf-native/main.rs
@@ -217,7 +217,7 @@ message Test {
     assert_eq!(fds.file(0).message_type(0).name(), b"Test");
     let mut out = vec![];
     fds.serialize_to_writer(&mut out)?;
-    assert!(out.len() > 0);
+    assert!(!out.is_empty());
     Ok(())
 }
 

--- a/protobuf-src/build.rs
+++ b/protobuf-src/build.rs
@@ -17,6 +17,7 @@ use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let install_dir = cmake::Config::new("protobuf")
+        .define("BUILD_SHARED_LIBS", "ON")
         .define("ABSL_PROPAGATE_CXX_STD", "ON")
         .define("protobuf_BUILD_TESTS", "OFF")
         .define("protobuf_DEBUG_POSTFIX", "")

--- a/protobuf-src/build.rs
+++ b/protobuf-src/build.rs
@@ -17,10 +17,16 @@ use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let install_dir = cmake::Config::new("protobuf")
-        .define("BUILD_SHARED_LIBS", "ON")
-        .define("ABSL_PROPAGATE_CXX_STD", "ON")
+        // Build STATIC libraries.
+        // See https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html
+        .define("BUILD_SHARED_LIBS", "OFF")
+        // Disable MSVC static runtime.
+        // This is enabled by default when BUILD_SHARED_LIBS is OFF.
+        // See https://cmake.org/cmake/help/latest/prop_tgt/MSVC_RUNTIME_LIBRARY.html
+        .define("protobuf_MSVC_STATIC_RUNTIME", "OFF")
         .define("protobuf_BUILD_TESTS", "OFF")
         .define("protobuf_DEBUG_POSTFIX", "")
+        .define("ABSL_PROPAGATE_CXX_STD", "ON")
         .define("CMAKE_CXX_STANDARD", "14")
         // CMAKE_INSTALL_LIBDIR is inferred as "lib64" on some platforms, but we
         // want a stable location that we can add to the linker search path.

--- a/protobuf-src/src/lib.rs
+++ b/protobuf-src/src/lib.rs
@@ -51,14 +51,22 @@
 
 use std::path::PathBuf;
 
+/// Installation directory.
+const INSTALL_DIR: &str = env!("INSTALL_DIR");
+
+/// *protoc* binary.
+#[cfg(target_os = "windows")]
+const PROTOC_BIN: &str = "protoc.exe";
+/// *protoc* binary.
+#[cfg(not(target_os = "windows"))]
+const PROTOC_BIN: &str = "protoc";
+
 /// Returns the path to the vendored protoc binary.
 pub fn protoc() -> PathBuf {
-    PathBuf::from(env!("INSTALL_DIR"))
-        .join("bin")
-        .join("protoc")
+    PathBuf::from(INSTALL_DIR).join("bin").join(PROTOC_BIN)
 }
 
 /// Returns the path to the vendored include directory.
 pub fn include() -> PathBuf {
-    PathBuf::from(env!("INSTALL_DIR")).join("include")
+    PathBuf::from(INSTALL_DIR).join("include")
 }

--- a/protobuf-src/src/lib.rs
+++ b/protobuf-src/src/lib.rs
@@ -55,10 +55,10 @@ use std::path::PathBuf;
 const INSTALL_DIR: &str = env!("INSTALL_DIR");
 
 /// *protoc* binary.
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 const PROTOC_BIN: &str = "protoc.exe";
 /// *protoc* binary.
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 const PROTOC_BIN: &str = "protoc";
 
 /// Returns the path to the vendored protoc binary.

--- a/protobuf-sys/build.rs
+++ b/protobuf-sys/build.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     ];
     autocxx_build::Builder::new("src/lib.rs", &include_paths)
         .build()?
-        .flag_if_supported("-std=c++14")
+        .std("c++14")
         .compile("protobuf-sys");
     println!("cargo:rerun-if-changed=src/lib.rs");
     println!(
@@ -122,6 +122,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         "absl_time_zone",
         "absl_utf8_for_code_point",
         "absl_vlog_config_internal",
+        #[cfg(windows)]
+        "libprotobuf",
+        #[cfg(not(windows))]
         "protobuf",
         "utf8_validity",
     ] {


### PR DESCRIPTION
Fix #4 

Force [BUILD_SHARED_LIBS](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html) to `OFF`.
On *Windows*, `protobuf`, especially older versions, can be problematic due to mixing *shared* and *static* libraries and mismatched *static*/*dynamic* runtime (see <https://github.com/protocolbuffers/protobuf/pull/20644>).